### PR TITLE
Adding --more-- markers so only the intro paragraph or so displays on the main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ layout: default
 This is my post.
 ```
 
+Posts should include a `<!--more-->` marker to separate the intro paragraph (which is displayed on
+the index page) from the rest of the post (which a reader would need to click through to the post
+page to read).
+
 ## And [Here is a Cycling Fish](https://giphy.com/embed/l46C9fDGilW6VoDGE)
 
 [Really!](https://giphy.com/embed/l46C9fDGilW6VoDGE)

--- a/_posts/2019-04-23-preservation-packaging.md
+++ b/_posts/2019-04-23-preservation-packaging.md
@@ -15,7 +15,7 @@ inter-related questions that took us a lot of discussion and exploration to reac
 consensus on are:
 1. What is the best unit of preservation?
 1. Should preservation packages be compressed and/or archived?
-
+<!--more-->
 
 ### What is the best unit of preservation?
 

--- a/_posts/2022-03-03-rails-with-subdirectory.md
+++ b/_posts/2022-03-03-rails-with-subdirectory.md
@@ -10,6 +10,7 @@ layout: default
 You know that sinking feeling you get when you've been working on an application for months, you're about to launch it, and then a new requirement appears at the last minute? It's been one of those weeks. However, after a couple of days of head scratching, I'm happy to report that we just might keep our launch schedule after all. 
 
 The requirement in question *shouldn't* be hard. We need to take [PDC Discovery](https://github.com/pulibrary/pdc_discovery), PUL's new research data discovery application, and serve it out at a subdirectory. So, instead of delivering it at `https://pdc-discovery-prod.princeton.edu` (which we always knew was a placeholder), it needs to appear at `https://datacommons.princeton.edu/discovery/`. That `/discovery` at the end is the tricky bit.
+<!--more-->
 
 ### Configuring the load balancer
 

--- a/_posts/2022-03-25-blacklight-dynamic-sitemap.md
+++ b/_posts/2022-03-25-blacklight-dynamic-sitemap.md
@@ -19,6 +19,7 @@ rake tasks to re-generate very large sitemaps is less than ideal because it
 takes time and the sitemaps become stale quickly. Given these drawbacks to our 
 existing approach, I was excited to try the more recent solution in use at 
 Stanford and Penn State (among others): [blacklight_dynamic_sitemap](https://github.com/sul-dlss/blacklight_dynamic_sitemap).
+<!--more-->
 
 [Jack Reed](https://github.com/mejackreed), one of the authors of this 
 solution, has a good [blog post](https://www.jack-reed.com/2020/01/10/sitemaps-that-scale.html) 

--- a/_posts/2022-11-04-moving-off-webpacker.md
+++ b/_posts/2022-11-04-moving-off-webpacker.md
@@ -18,6 +18,7 @@ Our Rails apps at PUL are not running on Rails 7 yet but we have been moving off
 of webpacker in preparation for this upgrade, and because webpacker is no longer
 supported. A number of us have tried a variety of options on a variety of apps,
 and we summarize our experiments and reflections here.
+<!--more-->
 
 ### Vite
 


### PR DESCRIPTION
Currently, several recent (and not-so-recent) posts display in their entirety on the main page because we didn't include `<!--more-->` markers. This PR adds them so just the intro paragraph displays and you have to click through to read the rest of the post.