### PR TITLE
Upgrade to Lux 5.6.1

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,14 +4,13 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <title>{{ site.title | default: site.github.repository_name }} by {{ site.github.owner_name }}</title>
-    <link rel="stylesheet" href="https://unpkg.com/lux-design-system@5.0.2/dist/style.css">
+    <link rel="stylesheet" href="https://unpkg.com/lux-design-system@5.6.1/dist/style.css">
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-    <script src="{{ '/assets/js/node-environment-for-vuex.js?v=' | append: site.github.build_revision | relative_url }}"></script>
     <script type="importmap">
       {
         "imports": {
           "vue": "https://unpkg.com/vue@3.2.47/dist/vue.esm-browser.prod.js",
-          "lux-design-system": "https://unpkg.com/lux-design-system@5.0.2/dist/lux-styleguidist.mjs"
+          "lux-design-system": "https://unpkg.com/lux-design-system@5.6.1/dist/lux-styleguidist.mjs"
         }
       }
     </script>

--- a/assets/js/node-environment-for-vuex.js
+++ b/assets/js/node-environment-for-vuex.js
@@ -1,7 +1,0 @@
-// The vuex packaged with lux 5 assumes that it
-// is in a node environment, rather than a browser
-window.process = {
-    env: {
-        NODE_ENV: 'production'
-    }
-};


### PR DESCRIPTION
This lux release has a fix for the node environment issue, so we no longer need the node-environment-for-vuex.js workaround.

For more information, see
https://github.com/pulibrary/lux-design-system/pull/325